### PR TITLE
Bug in the Message class

### DIFF
--- a/mqttws31.d.ts
+++ b/mqttws31.d.ts
@@ -19,23 +19,12 @@ export declare module Paho {
         }
 
         export class Message {
-            constructor();
-            constructor(payload: string);
-            
             payloadString: string;
             payloadBytes: Array<any>;
-
-            destinationName(): string;
-            destinationName(newDestinationName: string);
-
-            qos(): number;
-            qos(newQos: number);
-
-            retained(): boolean;
-            retained(newRetained: boolean);
-
-            duplicate(): boolean;
-            duplicate(newDuplicate: boolean);
+            destinationName : string;
+            qos: number;
+            retained: boolean;
+            duplicate: boolean;
         }
                    
         export class WireMessage {


### PR DESCRIPTION
The members of class should be properties (not functions).

Below a message structure:
![messageclass](https://cloud.githubusercontent.com/assets/4118364/19659226/741e2694-9a2b-11e6-808f-8222a573f3c0.png)
