### PR TITLE
Updating for newer TypeScript/Paho rules:

### DIFF
--- a/mqttws31.d.ts
+++ b/mqttws31.d.ts
@@ -1,32 +1,33 @@
-export declare module Paho {
-    export module MQTT {
+export declare namespace Paho {
+    export namespace MQTT {
         export class Client {
+            constructor(host: string, clientId: string);
             constructor(host: string, port: number, clientId: string);
             constructor(host: string, port: number, path: string, clientId: string);
-            connect(connectOptions: Object):void;
-            subscribe(filter: string, subscribeOptions: Object):void;
-            unsubscribe(filter: string, unsubscribeOptions: Object):void;
-            send(topic: string, payload: string, qos: number, retained: boolean):void;
-            disconnect():void;
-            getTraceLog():void;
-            startTrace():void;
-            stopTrace():void;
-            isConnected():boolean;
+            connect(connectOptions: Object): void;
+            subscribe(filter: string, subscribeOptions: Object): void;
+            unsubscribe(filter: string, unsubscribeOptions: Object): void;
+            send(topic: string, payload: string, qos: number, retained: boolean): void;
+            disconnect(): void;
+            getTraceLog(): void;
+            startTrace(): void;
+            stopTrace(): void;
+            isConnected(): boolean;
 
-            onConnectionLost(responseObject: Object):void;
-            onMessageDelivered():void;
-            onMessageArrived(message: Message):void;
+            onConnectionLost(responseObject: Object): void;
+            onMessageDelivered(): void;
+            onMessageArrived(message: Message): void;
         }
 
         export class Message {
             payloadString: string;
             payloadBytes: Array<any>;
-            destinationName : string;
+            destinationName: string;
             qos: number;
             retained: boolean;
             duplicate: boolean;
         }
-                   
+
         export class WireMessage {
             encode(): ArrayBuffer;
             decodeMessage(input: ArrayBuffer, pos: number): Array<any>;


### PR DESCRIPTION
* Using `namespace` instead of module
* Adding two-argument constructor definition
* Cleaning up whitespace

See: http://www.eclipse.org/paho/files/jsdoc/symbols/Paho.MQTT.Client.html#constructor

Client Constructor can take two to four arguments.

Would sincerely appreciate publishing a new version with these updates as well.